### PR TITLE
Ajout du réseau de transport de Clermont Ferrand

### DIFF
--- a/input.yaml
+++ b/input.yaml
@@ -138,6 +138,9 @@ datasets:
   # Métropole Toulon Provence Méditerranée
   - slug: reseau-de-transport-urbain-de-la-metropole-toulon-provence-mediterranee
     prefix: fr-toulon
+  # Métropole Clermont Ferrand (réseau T2C)
+  -slug: syndicat-mixte-des-transports-en-commun-de-lagglomeration-clermontoise-smtc-ac-reseau-t2c-gtfs-gtfs-rt
+   prefix: fr-clt-ferrand
 
   # Vannes
   - slug: reseau-urbain-kiceo


### PR DESCRIPTION
C'était la dernière métropole à intégrer
https://transport.data.gouv.fr/datasets/syndicat-mixte-des-transports-en-commun-de-lagglomeration-clermontoise-smtc-ac-reseau-t2c-gtfs-gtfs-rt